### PR TITLE
keywordize JSON prop names by default

### DIFF
--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -31,7 +31,7 @@
   "Sends the http request with formatted params"
   [connection params]
   (let [response (http/get (str (:api-url (verify connection)) params))]
-    (json/read-str (:body @response))))
+    (json/read-str (:body @response) :key-fn clojure.core/keyword)))
 
 (defn- make-query-string
   "Transforms a map into url params"


### PR DESCRIPTION
Arguably it's more idiomatic to clojure to have a map whose keys are keywords as it makes it easier/cleaner to inspect the responses.

This is a rather drastic, non-backwards compatible change and I'm fine if you decide not to merge, but I think it's worth giving the step.