### PR TITLE
Made post-message receive extra data

### DIFF
--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -19,9 +19,11 @@
   ([connection channel-id text]
      (post-message channel-id text {}))
   ([connection channel-id text extras]
-     (let [extras-map (stringify-keys extras)
-           post-message-args (merge {"channel" channel-id "text" text} extras-map)]
-       (slack-request connection "chat.postMessage" post-message-args))))
+     (->> extras
+          stringify-keys
+          (merge {"channel" channel-id
+                  "text" text})
+          (slack-request connection "chat.postMessage"))))
 
 (defn update
   "Sends a message to a channel."

--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -1,6 +1,15 @@
 (ns clj-slack.chat
   (:use [clj-slack.core :only [slack-request]]))
 
+(defn- parse-extras
+  "Takes a sequence and turns it into a hashmap whose keys are strings"
+  [extras]
+  (let [extras-map (apply hash-map extras)]
+    (into {} (for [[k v] extras-map]
+               (if (keyword? k)
+                 [(name k) v]
+                 [(str k) v])))))
+
 (defn delete
   "Deletes a message."
   [connection timestamp channel-id]
@@ -8,8 +17,10 @@
 
 (defn post-message
   "Sends a message to a channel."
-  [connection channel-id text]
-  (slack-request connection "chat.postMessage" {"channel" channel-id "text" text}))
+  [connection channel-id text & extras]
+  (let [extras-map (parse-extras extras)
+        post-message-args (merge {"channel" channel-id "text" text} extras-map)]
+    (slack-request connection "chat.postMessage" post-message-args)))
 
 (defn update
   "Sends a message to a channel."

--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -1,14 +1,13 @@
 (ns clj-slack.chat
   (:use [clj-slack.core :only [slack-request]]))
 
-(defn- parse-extras
-  "Takes a sequence and turns it into a hashmap whose keys are strings"
+(defn ^:private parse-extras
+  "Takes a sequence and turns it into a hashmap where keys are strings."
   [extras]
-  (let [extras-map (apply hash-map extras)]
-    (into {} (for [[k v] extras-map]
-               (if (keyword? k)
+  (into {} (for [[k v] (partition 2 extras)]
+             (if (keyword? k)
                  [(name k) v]
-                 [(str k) v])))))
+                 [(str k) v]))))
 
 (defn delete
   "Deletes a message."

--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -1,13 +1,5 @@
 (ns clj-slack.chat
-  (:use [clj-slack.core :only [slack-request]]))
-
-(defn ^:private stringify-keys
-  "Creates a new map whose keys are all strings."
-  [m]
-  (into {} (for [[k v] m]
-             (if (keyword? k)
-                 [(name k) v]
-                 [(str k) v]))))
+  (:use [clj-slack.core :only [slack-request stringify-keys]]))
 
 (defn delete
   "Deletes a message."

--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -1,10 +1,10 @@
 (ns clj-slack.chat
   (:use [clj-slack.core :only [slack-request]]))
 
-(defn ^:private parse-extras
-  "Takes a sequence and turns it into a hashmap where keys are strings."
-  [extras]
-  (into {} (for [[k v] (partition 2 extras)]
+(defn ^:private stringify-keys
+  "Creates a new map whose keys are all strings."
+  [m]
+  (into {} (for [[k v] m]
              (if (keyword? k)
                  [(name k) v]
                  [(str k) v]))))
@@ -16,10 +16,12 @@
 
 (defn post-message
   "Sends a message to a channel."
-  [connection channel-id text & extras]
-  (let [extras-map (parse-extras extras)
-        post-message-args (merge {"channel" channel-id "text" text} extras-map)]
-    (slack-request connection "chat.postMessage" post-message-args)))
+  ([connection channel-id text]
+     (post-message channel-id text {}))
+  ([connection channel-id text extras]
+     (let [extras-map (stringify-keys extras)
+           post-message-args (merge {"channel" channel-id "text" text} extras-map)]
+       (slack-request connection "chat.postMessage" post-message-args))))
 
 (defn update
   "Sends a message to a channel."

--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -52,3 +52,11 @@
   ([connection endpoint query]
    (let [params (build-params connection endpoint query)]
      (send-request connection params))))
+
+(defn stringify-keys
+  "Creates a new map whose keys are all strings."
+  [m]
+  (into {} (for [[k v] m]
+             (if (keyword? k)
+                 [(name k) v]
+                 [(str k) v]))))


### PR DESCRIPTION
Some context:

I'm writing a bot that will message members; `postMessage` [has a few optional arguments](https://api.slack.com/methods/chat.postMessage) that I'll need to customize. So now I can do things like:

```clojure
(slack-chat/post-message conn channel-id "some message"
      :username "my bot name"
      :icon_url "http://some.com/image.png")
```

This change is backwards compatible and can also be generalized for other API calls.