### PR TITLE
Deleted deprecated presence.set API call

### DIFF
--- a/src/clj_slack/presence.clj
+++ b/src/clj_slack/presence.clj
@@ -1,7 +1,0 @@
-(ns clj-slack.presence
-  (:use [clj-slack.core :only [slack-request]]))
-
-(defn set
-  "Manually set user presence."
-  [connection presence]
-  (slack-request connection "presence.set" {"presence" presence}))


### PR DESCRIPTION
This method was deprecated in favor of `users.setPresence`