### PR TITLE
Accept clojure data structures as attachments

### DIFF
--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -1,5 +1,12 @@
 (ns clj-slack.chat
-  (:use [clj-slack.core :only [slack-request stringify-keys]]))
+  (:use [clj-slack.core :only [slack-request stringify-keys]]
+        [clojure.data.json :only [write-str]]))
+
+(defn- serialize-attachments [options]
+  (let [attachments (:attachments options)]
+    (if (and attachments (not (string? attachments)))
+      (assoc options :attachments (write-str attachments))
+      options)))
 
 (defn delete
   "Deletes a message."
@@ -22,6 +29,7 @@
    (post-message connection channel-id text {}))
   ([connection channel-id text optionals]
    (->> optionals
+        serialize-attachments
         stringify-keys
         (merge {"channel" channel-id
                 "text" text})


### PR DESCRIPTION
Chat attachments must be sent as an encoded JSON array. This allows
users of clj-slack to do this:

```clojure
(post-message .... {:attachments [{:pretext "pre-hello"
                                   :text "text-world"}]})
```

Instead of

```clojure
(post-message .... {:attachments "[{\"pretext\": \"pre-hello\",
                                 \"text\": \"text-world\"}]"})
```

Although the later is still possible