### PR TITLE
Log when we don't get a valid response.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [http-kit "2.1.16"]
-                 [org.clojure/data.json "0.2.5"]])
+                 [org.clojure/data.json "0.2.5"]
+                 [org.clojure/tools.logging "0.3.1"]])

--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -1,7 +1,8 @@
 (ns clj-slack.core
   (:require
    [org.httpkit.client :as http]
-   [clojure.data.json :as json])
+   [clojure.data.json :as json]
+   [clojure.tools.logging :as log])
   (:import [java.net URLEncoder]))
 
 
@@ -32,7 +33,9 @@
   [url params]
   (let [full-url (str url params)
         response (http/get full-url)]
-    (json/read-str (:body @response) :key-fn clojure.core/keyword)))
+    (if-let [body (:body @response)]
+      (json/read-str body :key-fn clojure.core/keyword)
+      (log/error "Error from Slack API:" (:error @response)))))
 
 (defn- send-post-request
   "Sends a POST http request with formatted params"


### PR DESCRIPTION
Hi! 

Minor PR when I was debugging earlier today. Had a heck of a time figuring out what was up, and due to some JVM options I had set I was getting issues when I built a jar but not when I was using leiningen. This should help debug cases like that. Http-kit will give us an `:error` key if we don't get a valid response at all, so this just inspects that and logs it when appropriate. I added `clojure.tools.logging` to accommodate that.

Let me know if anything jumps out. Thank you!