### PR TITLE
replace http-kit with clj-http

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [http-kit "2.1.16"]
+                 [clj-http "2.0.0"]
                  [org.clojure/data.json "0.2.5"]
                  [org.clojure/tools.logging "0.3.1"]])

--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -35,7 +35,7 @@
         response (http/get full-url)]
     (if-let [body (:body response)]
       (json/read-str body :key-fn clojure.core/keyword)
-      (log/error "Error from Slack API:" (:error @response)))))
+      (log/error "Error from Slack API:" (:error response)))))
 
 (defn- send-post-request
   "Sends a POST http request with formatted params"

--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -1,6 +1,6 @@
 (ns clj-slack.core
   (:require
-   [org.httpkit.client :as http]
+   [clj-http.client :as http]
    [clojure.data.json :as json]
    [clojure.tools.logging :as log])
   (:import [java.net URLEncoder]))
@@ -33,7 +33,7 @@
   [url params]
   (let [full-url (str url params)
         response (http/get full-url)]
-    (if-let [body (:body @response)]
+    (if-let [body (:body response)]
       (json/read-str body :key-fn clojure.core/keyword)
       (log/error "Error from Slack API:" (:error @response)))))
 
@@ -41,7 +41,7 @@
   "Sends a POST http request with formatted params"
   [url multiparts]
   (let [response (http/post url {:multipart multiparts})]
-    (json/read-str (:body @response) :key-fn clojure.core/keyword)))
+    (json/read-str (:body response) :key-fn clojure.core/keyword)))
 
 (defn- make-query-string
   "Transforms a map into url params"


### PR DESCRIPTION
Since `http-kit` does not support proxies which is a requirement in firewall'd enterprise environments I just replaced it with `clj-http`. Since you don't have too much tests I checked with my use cases and it works fine. You might need to check the file handling part but otherwise their APIs are more or less the same. If you want to have me as a happy `clj-slack` user then please merge it - without proxy support I need to go on my on way. 