### PR TITLE
Oauth access and team API

### DIFF
--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -25,7 +25,8 @@
   "Checks the connection map"
   [connection]
   (verify-api-url connection)
-  (verify-token connection)
+  (when (not (contains? connection :skip-token-validation))
+    (verify-token connection))
   connection)
 
 (defn- send-request

--- a/src/clj_slack/oauth.clj
+++ b/src/clj_slack/oauth.clj
@@ -4,7 +4,10 @@
 (defn access
   "Exchanges a temporary OAuth code for an API token."
   [connection client-id client-secret code redirect-uri]
-  (slack-request connection "oauth.access" {"client_id" client-id
-                                            "client_secret" client-secret
-                                            "code" code
-                                            "redirect_uri" redirect-uri}))
+  (slack-request
+    (merge connection {:skip-token-validation true})
+    "oauth.access"
+    {"client_id" client-id
+     "client_secret" client-secret
+     "code" code
+     "redirect_uri" redirect-uri}))

--- a/src/clj_slack/team.clj
+++ b/src/clj_slack/team.clj
@@ -1,0 +1,19 @@
+(ns clj-slack.team
+  (:require [clj-slack.core :refer [slack-request stringify-keys]]))
+
+(defn access-log
+  "Gets the access logs for the current team.
+  Optional arguments are:
+  count: number of items to return per page
+  page: page number of results to return"
+  ([connection]
+    (slack-request connection "team.accessLog"))
+  ([connection optionals]
+   (->> optionals
+        stringify-keys
+        (slack-request connection "team.accessLog"))))
+
+(defn info
+  "Gets information about the current team."
+  [connection]
+  (slack-request connection "team.info"))

--- a/src/clj_slack/team.clj
+++ b/src/clj_slack/team.clj
@@ -7,11 +7,11 @@
   count: number of items to return per page
   page: page number of results to return"
   ([connection]
-    (slack-request connection "team.accessLog"))
+    (slack-request connection "team.accessLogs"))
   ([connection optionals]
    (->> optionals
         stringify-keys
-        (slack-request connection "team.accessLog"))))
+        (slack-request connection "team.accessLogs"))))
 
 (defn info
   "Gets information about the current team."


### PR DESCRIPTION
I used your library to authenticate to slack. if you don't have an oauth token but you want to get one using oauth2 you need to call oauth.access without one, that's the only method you can call without it so i did the change.
Also you were missing the team APIs.
Thanks for your work, very useful and simple to understand.