### PR TITLE
Fix oauth access

### DIFF
--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -25,7 +25,8 @@
   "Checks the connection map"
   [connection]
   (verify-api-url connection)
-  (verify-token connection)
+  (when (not (contains? connection :skip-token-validation))
+    (verify-token connection))
   connection)
 
 (defn- send-request

--- a/src/clj_slack/oauth.clj
+++ b/src/clj_slack/oauth.clj
@@ -4,7 +4,10 @@
 (defn access
   "Exchanges a temporary OAuth code for an API token."
   [connection client-id client-secret code redirect-uri]
-  (slack-request connection "oauth.access" {"client_id" client-id
-                                            "client_secret" client-secret
-                                            "code" code
-                                            "redirect_uri" redirect-uri}))
+  (slack-request
+    (merge connection {:skip-token-validation true})
+    "oauth.access"
+    {"client_id" client-id
+     "client_secret" client-secret
+     "code" code
+     "redirect_uri" redirect-uri}))

--- a/test/clj_slack/oauth_test.clj
+++ b/test/clj_slack/oauth_test.clj
@@ -9,5 +9,4 @@
 (deftest oauth-access
   (testing "Requesting a token with a temp code"
     (let [resp (clj-slack.oauth/access connection client-id client-secret "fake_temp_code" "http://example.com/fake/callback")]
-      (println resp)
-      (is (and (= false (:ok resp)) (= "invalid_code" (:error resp)))))))
+      (is (and (false? (:ok resp)) (= "invalid_code" (:error resp)))))))

--- a/test/clj_slack/oauth_test.clj
+++ b/test/clj_slack/oauth_test.clj
@@ -1,0 +1,13 @@
+(ns clj-slack.oauth-test
+  (:require [clojure.test :refer :all]
+            [clj-slack.oauth :refer :all]))
+
+(def connection {:api-url "https://slack.com/api"})
+(def client-id (System/getenv "CLIENT_ID"))
+(def client-secret (System/getenv "CLIENT_SECRET"))
+
+(deftest oauth-access
+  (testing "Requesting a token with a temp code"
+    (let [resp (clj-slack.oauth/access connection client-id client-secret "fake_temp_code" "http://example.com/fake/callback")]
+      (println resp)
+      (is (and (= false (:ok resp)) (= "invalid_code" (:error resp)))))))


### PR DESCRIPTION
Accept the connection object to be missing the token only if it comes from the oauth.access method.

Added a test that read client_id and client_secret from the environment and pass in a fake temp code so the reply is always an error: "invalid_code".
I think this is enough because we know that it hits the api in the right point and that the code is checked.