### PR TITLE
Set UTF-8 encoding type on multipart request

### DIFF
--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -62,8 +62,8 @@
   [params]
   (for [[k v] params]
     (if (instance? java.io.File v)
-      {:name k :content v :filename (.getName v)}
-      {:name k :content v})))
+      {:name k :content v :filename (.getName v) :encoding "UTF-8"}
+      {:name k :content v :encoding "UTF-8"})))
 
 (defn stringify-keys
   "Creates a new map whose keys are all strings."


### PR DESCRIPTION
This fixes posting emoji (or anything else that requires UTF-8). Without this patch, multipart requests are being sent in US-ASCII, e.g.:

```
--yXUu0RiBwsb0kT1vKSWxhvqlsjOxxlfiE
Content-Disposition: form-data; name="text"
Content-Type: text/plain; charset=US-ASCII
Content-Transfer-Encoding: 8bit

? and ? and ? and ?
```

the "?" above were attempts at sending emoji.