### PR TITLE
Fix wrong slack API call from reactions.remove

### DIFF
--- a/src/clj_slack/reactions.clj
+++ b/src/clj_slack/reactions.clj
@@ -49,4 +49,4 @@
   (->> optionals
        stringify-keys
        (merge {"name" name})
-       (slack-request connection "reactions.add")))
+       (slack-request connection "reactions.remove")))


### PR DESCRIPTION
Reactions.remove was previously actually sending the "reactions.add" call to slack, so trying to remove resulted in the error "already reacted."  Replaced with the correct remove call.