### PR TITLE
Added support for stars and the missing team method

### DIFF
--- a/src/clj_slack/stars.clj
+++ b/src/clj_slack/stars.clj
@@ -2,6 +2,19 @@
   (:require [clj-slack.core :refer [slack-request stringify-keys]])
   (:refer-clojure :exclude [list]))
 
+(defn add
+  "This method adds a star to an item on behalf of the authenticated user.
+  One of file, file_comment, channel, or the combination of channel and timestamp must be specified.
+  Optional arguments are:
+  - file: file to add star to
+  - file_comment: file comment to add star to
+  - channel: channel to add star to, or channel where the message to add star to was posted (used with timestamp)
+  - timestamp: used with channel, see above"
+  [connection optionals]
+  (->> optionals
+       stringify-keys
+       (slack-request connection "stars.add")))
+
 (defn list
   "Lists stars for a user.
   Optional arguments are:
@@ -14,3 +27,16 @@
    (->> optionals
         stringify-keys
         (slack-request connection "stars.list"))))
+
+(defn remove
+  "This method removes a star from an item on behalf of the authenticated user.
+  One of file, file_comment, channel, or the combination of channel and timestamp must be specified.
+  Optional arguments are:
+  - file: file to remove star from
+  - file_comment: file comment to remove star from
+  - channel: channel to remove star from, or channel where the message to remove star from was posted (used with timestamp)
+  - timestamp: used with channel, see above"
+  [connection optionals]
+  (->> optionals
+       stringify-keys
+       (slack-request connection "stars.remove")))

--- a/src/clj_slack/stars.clj
+++ b/src/clj_slack/stars.clj
@@ -1,6 +1,6 @@
 (ns clj-slack.stars
   (:require [clj-slack.core :refer [slack-request stringify-keys]])
-  (:refer-clojure :exclude [list]))
+  (:refer-clojure :exclude [list remove]))
 
 (defn add
   "This method adds a star to an item on behalf of the authenticated user.

--- a/src/clj_slack/team.clj
+++ b/src/clj_slack/team.clj
@@ -4,10 +4,10 @@
 (defn access-log
   "Gets the access logs for the current team.
   Optional arguments are:
-  count: number of items to return per page
-  page: page number of results to return"
+  - count: number of items to return per page
+  - page: page number of results to return"
   ([connection]
-    (slack-request connection "team.accessLogs"))
+   (access-log connection {}))
   ([connection optionals]
    (->> optionals
         stringify-keys
@@ -17,3 +17,15 @@
   "Gets information about the current team."
   [connection]
   (slack-request connection "team.info"))
+
+(defn integration-log
+  "This method lists the integration activity logs for a team,
+  including when integrations are added, modified and removed.
+  This method can only be called by Admins."
+  ([connection]
+   (integration-log connection {}))
+  ([connection optionals]
+   (->> optionals
+        stringify-keys
+        (slack-request connection "team.integrationLogs"))))
+


### PR DESCRIPTION
Hey, just added supported for adding and removing stars from stuff and the integration logs method.

Would a .md file with a table listing all implemented/non implemented slack methods be useful?