### PR TITLE
Fix warnings caused by replacing core functions

### DIFF
--- a/src/clj_slack/reactions.clj
+++ b/src/clj_slack/reactions.clj
@@ -1,4 +1,5 @@
 (ns clj-slack.reactions
+  (:refer-clojure :exclude [get list remove])
   (:require [clj-slack.core :refer [slack-request stringify-keys]]))
 
 (defn add


### PR DESCRIPTION
Excludes the clojure.core functions from this namespace to fix these warnings:

```WARNING: get already refers to: #'clojure.core/get in namespace: clj-slack.reactions, being replaced by: #'clj-slack.reactions/get
WARNING: list already refers to: #'clojure.core/list in namespace: clj-slack.reactions, being replaced by: #'clj-slack.reactions/list
WARNING: remove already refers to: #'clojure.core/remove in namespace: clj-slack.reactions, being replaced by: #'clj-slack.reactions/remove
```

AFAIK there is no way to suppress them on the consumer side.

Btw, thanks for writing `clj-slack`!