### PR TITLE
Fix mpim implementation

### DIFF
--- a/src/clj_slack/mpim.clj
+++ b/src/clj_slack/mpim.clj
@@ -1,4 +1,4 @@
-(ns clj-slack.mpin
+(ns clj-slack.mpim
   (:require [clj-slack.core :refer [slack-request stringify-keys]])
   (:refer-clojure :exclude [list]))
 

--- a/src/clj_slack/mpim.clj
+++ b/src/clj_slack/mpim.clj
@@ -5,7 +5,7 @@
 (defn close
   "Closes a multiparty direct message channel."
   [connection channel-id]
-  (slack-request connection "mpin.close" {"channel" channel-id}))
+  (slack-request connection "mpim.close" {"channel" channel-id}))
 
 (defn history
   "Fetches history of messages and events from a multiparty direct message.`
@@ -21,19 +21,19 @@
    (->> optionals
         stringify-keys
         (merge {"channel" channel-id})
-        (slack-request connection "mpin.history"))))
+        (slack-request connection "mpim.history"))))
 
 (defn list
   "Lists multiparty direct message channels for the calling user."
   [connection]
-  (slack-request connection "mpin.list"))
+  (slack-request connection "mpim.list"))
 
 (defn mark
   "Sets the read cursor in a multiparty direct message channel."
   [connection channel-id timestamp]
-  (slack-request connection "mpin.mark" {"channel" channel-id "ts" timestamp}))
+  (slack-request connection "mpim.mark" {"channel" channel-id "ts" timestamp}))
 
 (defn open
   "This method opens a multiparty direct message."
-  [connection user-id]
-  (slack-request connection "mpin.open" {"user" user-id}))
+  [connection user-ids]
+  (slack-request connection "mpim.open" {"users" (clojure.string/join "," user-ids)}))


### PR DESCRIPTION
Fix mpim implementation:
- rename mpin.clj -> mpim.clj
- s/mpin/mpim/
- `open` takes comma separated user-ids, not a single user-id.

Guessing this wasn't tested. 😸 