### PR TITLE
Add rtm.connect

### DIFF
--- a/src/clj_slack/rtm.clj
+++ b/src/clj_slack/rtm.clj
@@ -5,3 +5,9 @@
   "Starts a Real Time Messaging session."
   [connection]
   (slack-request connection "rtm.start"))
+
+(defn connect
+  "Starts a Real Time Messaging session. Recommended over start:
+  https://api.slack.com/rtm"
+  [connection]
+  (slack-request connection "rtm.connect"))


### PR DESCRIPTION
Adds a `clj-slack.rtm/connect` function that uses the `rtm.connect` slack api. The `rtm.connect` api is recommended over `rtm.start` in the Slack docs: https://api.slack.com/rtm.

Thanks for the library!