### PR TITLE
Use Basic auth in oauth/access instead of query params

### DIFF
--- a/src/clj_slack/oauth.clj
+++ b/src/clj_slack/oauth.clj
@@ -2,12 +2,13 @@
   (:require [clj-slack.core :refer [slack-request]]))
 
 (defn access
-  "Exchanges a temporary OAuth code for an API token."
+  "Exchanges a temporary OAuth code for an API token.
+
+  Provides client-id and client-secret using HTTP Basic auth."
   [connection client-id client-secret code redirect-uri]
   (slack-request
-    (merge connection {:skip-token-validation true})
+    (merge connection {:skip-token-validation true
+                       :basic-auth [client-id client-secret]})
     "oauth.access"
-    {"client_id" client-id
-     "client_secret" client-secret
-     "code" code
+    {"code" code
      "redirect_uri" redirect-uri}))


### PR DESCRIPTION
It is recommended to provide the client-id and client-secret as Basic
auth, instead of query params.

See: https://api.slack.com/methods/oauth.access and
https://tools.ietf.org/html/rfc6749#section-2.3.1

Fixes #50