### PR TITLE
add view.open support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.julienxx/clj-slack "0.6.3"
+(defproject org.julienxx/clj-slack "0.7.0"
   :description "Slack REST API wrapper"
   :url "http://github.com/julienXX/clj-slack"
   :license {:name "Eclipse Public License"

--- a/src/clj_slack/views.clj
+++ b/src/clj_slack/views.clj
@@ -1,0 +1,13 @@
+(ns clj-slack.views
+  (:require [clj-slack.core :refer [slack-post-request]]))
+
+(defn open
+  "Opens a view for the user that caused the trigger trigger-id.
+
+  - view: a json encoded string of a view
+  - trigger-id: the trigger-id of the event that the view will open for
+
+  See: https://api.slack.com/methods/views.open
+  "
+  [connection view trigger-id]
+  (slack-post-request connection "views.open" {"view" view "trigger_id" trigger-id}))


### PR DESCRIPTION
Hey, thanks for providing clj-slack, it's awesome.

I added support for the new `views.open` that is supposed to be used in place of `dialog`.