### PR TITLE
Fix broken auth tokens

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.6.0"}, clj-http {:mvn/version "2.0.0"}, org.clojure/data.json {:mvn/version "0.2.5"}, org.clojure/tools.logging {:mvn/version "0.3.1"}}}
+ :deps {org.clojure/clojure {:mvn/version "1.6.0"},
+        clj-http/clj-http {:mvn/version "2.0.0"},
+        org.clojure/data.json {:mvn/version "0.2.5"},
+        org.clojure/tools.logging {:mvn/version "0.3.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.6.0"}, clj-http {:mvn/version "2.0.0"}, org.clojure/data.json {:mvn/version "0.2.5"}, org.clojure/tools.logging {:mvn/version "0.3.1"}}}


### PR DESCRIPTION
Hi there,
I'm creating a new Slack bot and I can't use the version of this library on Clojars.  Could this PR be merged and a new release made please?
Reference: https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps
