### PR TITLE
Made compatible with Babashka

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 clj-slack is a Clojure library to talk to the [Slack](http://slack.com) REST API. It supports almost the entire Slack API.
 
 ![Build Status](https://travis-ci.org/julienXX/clj-slack.svg?branch=master)
+[![bb compatible](https://raw.githubusercontent.com/babashka/babashka/master/logo/badge.svg)](https://babashka.org)
 
 ## Documentation
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.6.0"},
-        clj-http/clj-http {:mvn/version "2.0.0"},
-        org.clojure/data.json {:mvn/version "0.2.5"},
+        org.clj-commons/clj-http-lite {:mvn/version "1.0.13"},
+        cheshire/cheshire  {:mvn/version "5.11.0"},
         org.clojure/tools.logging {:mvn/version "0.3.1"}}}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-http "3.12.3"]
-                 [org.clojure/data.json "2.4.0"]
+                 [org.clj-commons/clj-http-lite "1.0.13"]
+                 [cheshire/cheshire "5.11.0"]
                  [org.clojure/tools.logging "1.2.4"]]
   :deploy-repositories [["clojars"  {:sign-releases false}]])

--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -1,12 +1,12 @@
 (ns clj-slack.chat
   (:refer-clojure :exclude [update])
   (:require [clj-slack.core :refer [slack-request slack-post-request stringify-keys]]
-            [clojure.data.json :refer [write-str]]))
+            [cheshire.core :refer [generate-string]]))
 
 (defn- serialize-option [option-key options]
   (let [option-value (option-key options)]
     (if (and option-value (not (string? option-value)))
-      (assoc options option-key (write-str option-value))
+      (assoc options option-key (generate-string option-value))
       options)))
 
 (defn delete

--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -1,7 +1,7 @@
 (ns clj-slack.core
   (:require
-   [clj-http.client :as http]
-   [clojure.data.json :as json]
+   [clj-http.lite.client :as http]
+   [cheshire.core :as json]
    [clojure.tools.logging :as log])
   (:import [java.net URLEncoder]))
 
@@ -39,7 +39,7 @@
                  "Authorization" (str "Bearer " token)}
         response (http/get full-url (merge {:headers headers} opts))]
     (if-let [body (:body response)]
-      (json/read-str body :key-fn clojure.core/keyword)
+      (json/parse-string body true)
       (log/error "Error from Slack API:" (:error response)))))
 
 (defn- send-post-request
@@ -49,10 +49,10 @@
   [url token post-params & [opts]]
   (let [headers {"Content-Type" "application/json"
                  "Authorization" (str "Bearer " token)}
-        response (http/post url (merge {:body (json/write-str post-params)
+        response (http/post url (merge {:body (json/generate-string post-params)
                                         :headers headers}
                                        opts))]
-    (json/read-str (:body response) :key-fn clojure.core/keyword)))
+    (json/parse-string (:body response) true)))
 
 (defn- make-query-string
   "Transforms a map into url params"


### PR DESCRIPTION
[Babashka](https://babashka.org) is great for writing scripts in Clojure. We use it for our CI and deployment scripts. I find it quite common wanting to send automated messages to Slack from our scripts.

clj-slack has two dependencies which are not compatible with Babashka: **clj-http** and **data.json**. They can be easily replaced with **clj-http-lite** and **cheshire**, both of which are compatible. This is what this PR is for.

`lein test` on your trunk isn't fully working for me. Not sure why. This PR doesn't add any additional failures or errors.

I'm using `chat` and `reactions` from my scripts now.