### PR TITLE
feat: include UTF-8 charset in POST HTTP request Content-Type header

### DIFF
--- a/src/clj_slack/core.clj
+++ b/src/clj_slack/core.clj
@@ -47,7 +47,7 @@
   Optional request options can be specified which will be passed to `clj-http` without any changes.
   Can be useful to specify timeouts, etc."
   [url token post-params & [opts]]
-  (let [headers {"Content-Type" "application/json"
+  (let [headers {"Content-Type" "application/json; charset=utf-8"
                  "Authorization" (str "Bearer " token)}
         response (http/post url (merge {:body (json/write-str post-params)
                                         :headers headers}


### PR DESCRIPTION
This avoids the https://api.slack.com/methods/chat.postMessage#warnings `missing_charset` warning.