### PR TITLE
Update oauth endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ clj-slack documentation is available [here](http://julienblanchard.com/clj-slack
 
 ## Usage
 
-This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.6.3"]``` to your ```:dependencies``` in your project.clj file.
+This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.8.1"]``` to your ```:dependencies``` in your project.clj file.
 
 Get your access token by creating a new app or [here](https://api.slack.com/custom-integrations/legacy-tokens). If you create a new Slack app, **don't forget to add the relevant scopes to your app**.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.julienxx/clj-slack "0.8.0"
+(defproject org.julienxx/clj-slack "0.8.1"
   :description "Slack REST API wrapper"
   :url "http://github.com/julienXX/clj-slack"
   :license {:name "Eclipse Public License"

--- a/src/clj_slack/oauth.clj
+++ b/src/clj_slack/oauth.clj
@@ -9,6 +9,6 @@
   (slack-request
     (merge connection {:skip-token-validation true
                        :basic-auth [client-id client-secret]})
-    "oauth.access"
+    "oauth.v2.access"
     {"code" code
      "redirect_uri" redirect-uri}))


### PR DESCRIPTION
This PR updates the endpoint used for OAuth to the `v2` version, otherwise Slack responds with `oauth_authorization_url_mismatch`. See also the official docs: https://api.slack.com/methods/oauth.v2.access#errors