### PR TITLE
Add more chat methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ clj-slack documentation is available [here](http://julienblanchard.com/clj-slack
 
 ## Usage
 
-This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.8.1"]``` to your ```:dependencies``` in your project.clj file.
+This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.9.0"]``` to your ```:dependencies``` in your project.clj file.
 
 Get your access token by creating a new app or [here](https://api.slack.com/custom-integrations/legacy-tokens). If you create a new Slack app, **don't forget to add the relevant scopes to your app**.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ clj-slack documentation is available [here](http://julienblanchard.com/clj-slack
 
 ## Usage
 
-This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.6.3"]``` to your ```:dependencies``` in your project.clj file.
+This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.8.1"]``` to your ```:dependencies``` in your project.clj file.
 
 Get your access token by creating a new app or [here](https://api.slack.com/custom-integrations/legacy-tokens). If you create a new Slack app, **don't forget to add the relevant scopes to your app**.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.julienxx/clj-slack "0.8.1"
+(defproject org.julienxx/clj-slack "0.9.0"
   :description "Slack REST API wrapper"
   :url "http://github.com/julienXX/clj-slack"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.julienxx/clj-slack "0.8.0"
+(defproject org.julienxx/clj-slack "0.8.1"
   :description "Slack REST API wrapper"
   :url "http://github.com/julienXX/clj-slack"
   :license {:name "Eclipse Public License"

--- a/src/clj_slack/chat.clj
+++ b/src/clj_slack/chat.clj
@@ -40,7 +40,41 @@
                 "text" text})
         (slack-post-request connection "chat.postMessage"))))
 
+(defn post-ephemeral
+  "Sends an ephemeral message to a user in a channel.
+  Optional arguments are:
+  - username: name of bot
+  - as_user: pass true (as a string) to post the message as the authed user, instead of as a bot
+  - parse: change how messages are treated
+  - link_names: find and link channel names and usernames
+  - blocks: structured message blocks
+  - attachments: structured message attachments. (NB: Slack recommends using Blocks
+    instead of legacy attachments:
+    https://api.slack.com/messaging/composing/layouts#secondary-attachments)
+  - unfurl_links: pass true to enable unfurling of primarily text-based content
+  - unfurl_media: pass false to disable unfurling of media content
+  - icon_url: URL to an image to use as the icon for this message
+  - icon_emoji: emoji to use as the icon for this message. Overrides icon_url
+  - thread_ts: Provide another message's ts value to post this message in a thread. 
+    Avoid using a reply's ts value; use its parent's value instead.
+    Ephemeral messages in threads are only shown if there is already an active thread."
+  ([connection channel-id text]
+   (post-ephemeral connection channel-id text {}))
+  ([connection channel-id text optionals]
+   (->> optionals
+        (serialize-option :blocks)
+        (serialize-option :attachments)
+        stringify-keys
+        (merge {"channel" channel-id
+                "text" text})
+        (slack-post-request connection "chat.postEphemeral"))))
+
 (defn update
   "Sends a message to a channel."
   [connection timestamp channel-id text]
   (slack-request connection "chat.update" {"ts" timestamp "channel" channel-id "text" text}))
+
+(defn get-permalink
+  "Retrieve a permalink URL for a specific extant message"
+  [connection channel-id message-ts]
+  (slack-request connection "chat.getPermalink" {"channel" channel-id "message_ts" message-ts}))

--- a/src/clj_slack/oauth.clj
+++ b/src/clj_slack/oauth.clj
@@ -9,6 +9,6 @@
   (slack-request
     (merge connection {:skip-token-validation true
                        :basic-auth [client-id client-secret]})
-    "oauth.access"
+    "oauth.v2.access"
     {"code" code
      "redirect_uri" redirect-uri}))


### PR DESCRIPTION
This PR adds functions for `postEphemeral` and `getPermalink`.
I literally copy-pasted the `post-message` function and renamed it accordingly, changed the endpoint. If you would prefer, I can also abstract the code used in each, so that it's not duplicated. I thought that for now this would be fine :)