### PR TITLE
Add bots.info method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ clj-slack documentation is available [here](http://julienblanchard.com/clj-slack
 
 ## Usage
 
-This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.8.1"]``` to your ```:dependencies``` in your project.clj file.
+This is on [Clojars](https://clojars.org/org.julienxx/clj-slack) of course. Just add ```[org.julienxx/clj-slack "0.8.2"]``` to your ```:dependencies``` in your project.clj file.
 
 Get your access token by creating a new app or [here](https://api.slack.com/custom-integrations/legacy-tokens). If you create a new Slack app, **don't forget to add the relevant scopes to your app**.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.julienxx/clj-slack "0.8.1"
+(defproject org.julienxx/clj-slack "0.8.2"
   :description "Slack REST API wrapper"
   :url "http://github.com/julienXX/clj-slack"
   :license {:name "Eclipse Public License"

--- a/src/clj_slack/bots.clj
+++ b/src/clj_slack/bots.clj
@@ -1,0 +1,8 @@
+(ns clj-slack.bots
+  (:require [clj-slack.core :refer [slack-request]]))
+
+(defn info
+  "Gets information about a bot."
+  [connection bot-id]
+  (slack-request connection "bots.info" {"bot" bot-id}))
+


### PR DESCRIPTION
Small one this time :)
Adds a new namespace `clj-slack.bots` and a new function `info` which retrieves information about a bot.
Official docs at https://api.slack.com/methods/bots.info

Bumped minor version as per your request in the other PR.